### PR TITLE
Sec Shades Returns

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -45,7 +45,7 @@
     back: ClothingBackpackHOSFilled
     shoes: ClothingShoesBootsCombatFilled
     outerClothing: ClothingOuterCoatHoSTrench
-    eyes: ClothingEyesGlassesSunglasses
+    eyes: ClothingEyesGlassesSecurity # Grey Station - Replaced Regular Sunglasses
     head: ClothingHeadHatBeretHoS
     id: HoSPDA
     gloves: ClothingHandsGlovesCombat

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -27,7 +27,7 @@
     jumpsuit: ClothingUniformJumpsuitSec
     back: ClothingBackpackSecurityFilled
     shoes: ClothingShoesBootsCombatFilled
-    eyes: ClothingEyesGlassesSunglasses
+    eyes: ClothingEyesGlassesSecurity # Grey Station - Replaced Regular Sunglasses
     head: ClothingHeadHelmetBasic
     outerClothing: ClothingOuterArmorPlateCarrier # Grey Station - ClothingOuterArmorPlateCarrier
     id: SecurityPDA

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -30,7 +30,7 @@
     jumpsuit: ClothingUniformJumpsuitWarden
     back: ClothingBackpackSecurityFilled
     shoes: ClothingShoesBootsCombatFilled
-    eyes: ClothingEyesGlassesSunglasses
+    eyes: ClothingEyesGlassesSecurity # Grey Station - Replaced Regular Sunglasses
     outerClothing: ClothingOuterCoatWarden
     id: WardenPDA
     ears: ClothingHeadsetSecurity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Gave Sec Officer's, Warden, and HoS Sec shades to replace the default sunglasses.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Sec gets no respect, no respect at all. (NOTE: Will add crafting recipe in future PR for sec shades by combining Sec Hud + Sunglasses.)

## Media
![image](https://github.com/greystation14/GreyStation14/assets/113228053/bf559de5-3032-4e59-82e2-74904affd9d9)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame
**Changelog**

:cl:
- add: Added Sec Shades to Sec Officer's, Warden, and HoS