### PR TITLE
Separate Certain Walls

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -78,7 +78,7 @@
         acts: [ "Destruction" ]
 
   - type: IconSmooth
-    key: walls
+    key: bricks #GreyStation - Make it so they can't join other walls.
     base: brick
 
 - type: entity
@@ -988,7 +988,7 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: IconSmooth
-    key: walls
+    key: woods #GreyStation - Make it so they can't join other walls.
     base: wood
 
 - type: entity
@@ -1234,7 +1234,7 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: IconSmooth
-    key: walls
+    key: cobblebricks #GreyStation - Make it so they can't join other walls.
     base: cobblebrick
 
 - type: entity
@@ -1247,7 +1247,7 @@
   - type: Icon
     sprite: Structures/Walls/cobblebrick_basalt.rsi
   - type: IconSmooth
-    key: walls
+    key: cobblebricks #GreyStation - Make it so they can't join other walls.
     base: cobblebrick
 
 - type: entity
@@ -1261,7 +1261,7 @@
   - type: Icon
     sprite: Structures/Walls/cobblebrick_snow.rsi
   - type: IconSmooth
-    key: walls
+    key: cobblebricks #GreyStation - Make it so they can't join other walls.
     base: cobblebrick
 
 - type: entity
@@ -1274,7 +1274,7 @@
   - type: Icon
     sprite: Structures/Walls/cobblebrick_asteroid.rsi
   - type: IconSmooth
-    key: walls
+    key: cobblebricks #GreyStation - Make it so they can't join other walls.
     base: cobblebrick
 
 - type: entity
@@ -1287,7 +1287,7 @@
   - type: Icon
     sprite: Structures/Walls/cobblebrick_sand.rsi
   - type: IconSmooth
-    key: walls
+    key: cobblebricks #GreyStation - Make it so they can't join other walls.
     base: cobblebrick
 
 - type: entity
@@ -1300,7 +1300,7 @@
   - type: Icon
     sprite: Structures/Walls/cobblebrick_chromite.rsi
   - type: IconSmooth
-    key: walls
+    key: cobblebricks #GreyStation - Make it so they can't join other walls.
     base: cobblebrick
 
 - type: entity
@@ -1313,5 +1313,5 @@
   - type: Icon
     sprite: Structures/Walls/cobblebrick_andesite.rsi
   - type: IconSmooth
-    key: walls
+    key: cobblebricks #GreyStation - Make it so they can't join other walls.
     base: cobblebrick

--- a/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/Random/devices.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/Random/devices.yml
@@ -58,6 +58,7 @@
       - SurveillanceWirelessCameraMonitorCircuitboard
       - SurveillanceWirelessCameraAnchoredCircuitboard
       - NotekeeperCartridge
+      - NewsReaderCartridge
       - GeigerCounter
       - Holoprojector
       - HolofanProjector

--- a/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/Random/devices.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/Random/devices.yml
@@ -58,7 +58,6 @@
       - SurveillanceWirelessCameraMonitorCircuitboard
       - SurveillanceWirelessCameraAnchoredCircuitboard
       - NotekeeperCartridge
-      - NewsReadCartridge
       - GeigerCounter
       - Holoprojector
       - HolofanProjector


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Made it so brick walls and wood walls don't conjoin with other walls.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
To make the walls look less visually jarring.

**Changelog**
:cl:
- tweak: Changed certain wall to not conjoin