### PR TITLE
Remove wide swinging + ghost roles from certain animals and all slimes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2213,7 +2213,7 @@
       0: Alive
       90: Dead
   - type: MeleeWeapon
-    altDisarm: false
+    #altDisarm: false - GreyStation
     angle: 0
     animation: WeaponArcBite
     soundHit:
@@ -2339,7 +2339,7 @@
     - type: Spider
       webPrototype: SpiderWebClown
     - type: MeleeWeapon
-      altDisarm: false
+      #altDisarm: false - GreyStation
       angle: 0
       animation: WeaponArcBite
       soundHit:
@@ -2789,7 +2789,7 @@
     interactSuccessSound:
       path: /Audio/Animals/cat_meow.ogg
   - type: MeleeWeapon
-    altDisarm: false
+    #altDisarm: false - GreyStation
     angle: 0
     animation: WeaponArcBite
     soundHit:
@@ -2857,7 +2857,7 @@
     factions:
     - Syndicate
   - type: MeleeWeapon
-    altDisarm: false
+    #altDisarm: false - GreyStation
     angle: 0
     animation: WeaponArcBite
     soundHit:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -93,7 +93,7 @@
     prototype: Slimes
     requiredLegs: 1
   - type: MeleeWeapon
-    altDisarm: false
+    #altDisarm: false - GreyStation
     soundHit:
         path: /Audio/Weapons/punch3.ogg
     angle: 0
@@ -122,12 +122,12 @@
   components:
   - type: ReplacementAccent
     accent: slimes
-  - type: GhostTakeoverAvailable
-  - type: GhostRole
-    makeSentient: true
-    name: ghost-role-information-slimes-name
-    description: ghost-role-information-slimes-description
-    raffle:
+  #- type: GhostTakeoverAvailable - GreyStation
+  #- type: GhostRole
+  #  makeSentient: true
+  #  name: ghost-role-information-slimes-name
+  #  description: ghost-role-information-slimes-description
+  #  raffle:
       settings: short
   - type: Speech
     speechVerb: Slime
@@ -198,10 +198,10 @@
     - type: NpcFactionMember
       factions:
         - SimpleHostile
-    - type: GhostRole
-      description: ghost-role-information-angry-slimes-description
-      raffle:
-        settings: short
+    #- type: GhostRole - GreyStation
+    #  description: ghost-role-information-angry-slimes-description
+    #  raffle:
+    #    settings: short
 
 - type: entity
   name: green slime
@@ -235,10 +235,10 @@
     - type: NpcFactionMember
       factions:
         - SimpleHostile
-    - type: GhostRole
-      description: ghost-role-information-angry-slimes-description
-      raffle:
-        settings: short
+    #- type: GhostRole - GreyStation
+    #  description: ghost-role-information-angry-slimes-description
+    #  raffle:
+    #    settings: short
 
 - type: entity
   name: yellow slime
@@ -272,7 +272,7 @@
     - type: NpcFactionMember
       factions:
         - SimpleHostile
-    - type: GhostRole
-      description: ghost-role-information-angry-slimes-description
-      raffle:
-        settings: short
+    #- type: GhostRole - GreyStation
+    #  description: ghost-role-information-angry-slimes-description
+    #  raffle:
+    #    settings: short

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -128,7 +128,7 @@
   #  name: ghost-role-information-slimes-name
   #  description: ghost-role-information-slimes-description
   #  raffle:
-      settings: short
+  #    settings: short
   - type: Speech
     speechVerb: Slime
     speechSounds: Slime


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removed wide swinging + ghost roles from certain animals and all slimes
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It doesn't make sense that things that don't have hands are able to wide-swing. Really I think it makes combat extremely dumbed down whereas now they'll have to actually click on the target to hit it.

I also removed ghost roles from spiders and slimes due to them being abused and teaming up with nukies a bit too often. Might go back on this decision in the future if there's some way to ensure or discourage this behavior without admin intervention.

**Changelog**
:cl:
- remove: Removed wide swinging from certain animals and all slimes
- remove: Removed ghost roles for spiders and slimes