### PR TITLE
Return of the old AME sound

### DIFF
--- a/Content.Server/Ame/Components/AmeControllerComponent.cs
+++ b/Content.Server/Ame/Components/AmeControllerComponent.cs
@@ -51,11 +51,11 @@ public sealed partial class AmeControllerComponent : SharedAmeControllerComponen
     public SoundSpecifier ClickSound = new SoundPathSpecifier("/Audio/Machines/machine_switch.ogg");
 
     /// <summary>
-    /// The sound used when injecting antimatter into the AME.
+    /// The sound used when injecting antimatter into the AME. #GreyStation - Changed it to bang.ogg
     /// </summary>
     [DataField("injectSound")]
     [ViewVariables(VVAccess.ReadWrite)]
-    public SoundSpecifier InjectSound = new SoundCollectionSpecifier("MetalThud");
+    public SoundSpecifier InjectSound = new SoundPathSpecifier("/Audio/Weapons/Guns/Gunshots/bang.ogg");
 
     /// <summary>
     /// The last time this could have injected fuel into the AME.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Re-Added the old AME sound.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It's a classic, plus the new sound doesn't sound right for a giant-power source machine. Down the line this might get replaced to a more fitting sound but out of the two the old AME sounded better.

**Changelog**

:cl:
- add: Added the old AME sound back