### PR TITLE
Remove Extra Nuke Disk Steal Objective

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -23,7 +23,6 @@
     HandTeleporterStealObjective: 0.5
     SecretDocumentsStealObjective: 0.5
     HoSGunStealObjective: 0.5 # Delta-V - HoS Gun
-    NukeDiskStealObjective: 0.25
 
 - type: weightedRandom
   id: TraitorObjectiveGroupKill


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes a accidental leftover part of the YML from a recent upstream merge.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Game no work, work good now much lot.

**Changelog**
:cl:
- fix: Fixed nuke disk steal goal objective