### PR TITLE
Remove Walking Solar Systems/Anomaly Core Rotating Ability

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -84,7 +84,7 @@
       modifier: 0.1
     - type: Tag
       tags:
-        - ForceableFollow
+#        - ForceableFollow # GreyStation - Remove following ghosts
         - PlushieGhost
         - Payload
     - type: RandomWalk

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
@@ -26,9 +26,9 @@
       collection: RadiationPulse
   - type: UseDelay
     delay: 2
-  - type: Tag
-    tags:
-    - ForceableFollow
+#  - type: Tag # GreyStation - No more walking solar systems
+#    tags:
+#    - ForceableFollow
   - type: AnomalyCore
     timeToDecay: 600
     startPrice: 10000


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removed the force follow ability for anomaly cores.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I don't think it really makes sense for anomaly cores to just float around the player, let alone having a limitless amount of cores to rotate around you.

**Changelog**
:cl:
- remove: Removed anomaly cores rotating