### PR TITLE
Remove Rat King wideswing

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -48,7 +48,7 @@
       0: Alive
       200: Dead
   - type: MeleeWeapon
-#    altDisarm: false
+#    altDisarm: false - GreyStation
     soundHit:
         path: /Audio/Weapons/Xeno/alien_claw_flesh1.ogg
     angle: 0
@@ -142,7 +142,7 @@
       0: Alive
       350: Dead
   - type: MeleeWeapon
-#    altDisarm: false
+#    altDisarm: false - GreyStation
     soundHit:
         path: /Audio/Weapons/Xeno/alien_claw_flesh2.ogg
     angle: 0

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -48,7 +48,7 @@
       0: Alive
       200: Dead
   - type: MeleeWeapon
-    altDisarm: false
+#    altDisarm: false
     soundHit:
         path: /Audio/Weapons/Xeno/alien_claw_flesh1.ogg
     angle: 0
@@ -142,7 +142,7 @@
       0: Alive
       350: Dead
   - type: MeleeWeapon
-    altDisarm: false
+#    altDisarm: false
     soundHit:
         path: /Audio/Weapons/Xeno/alien_claw_flesh2.ogg
     angle: 0


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removed the wideswing attack move from the Rat King
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I dislike a lot of mobs having wide swinging abilities as it lowers any effort of combat to just running close and wide swinging instead of trying to aim at the thing you want to hit.
