### PR TITLE
no more blind/pacifist sec or captain

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -18,6 +18,11 @@
 #      time: 54000 # 15 hours
     - !type:AgeRequirement
       requiredAge: 21
+    - !type:TraitsRequirement # No Pacifist or Blind Sec
+    inverted: true
+    traits:
+    - Pacifist
+    - Blindness
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -19,8 +19,8 @@
     - !type:AgeRequirement
       requiredAge: 21
     - !type:TraitsRequirement # No Pacifist or Blind Sec
-    inverted: true
-    traits:
+      inverted: true
+      traits:
     - Pacifist
     - Blindness
   weight: 20

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -4,25 +4,13 @@
   description: job-description-captain
   playTimeTracker: JobCaptain
   requirements:
-#    - !type:DepartmentTimeRequirement
-#      department: Engineering
-#      time: 54000 # 15 hours
-#    - !type:DepartmentTimeRequirement
-#      department: Medical
-#      time: 54000 # 15 hours
-#    - !type:DepartmentTimeRequirement
-#      department: Security
-#      time: 54000 # 15 hours
-#    - !type:DepartmentTimeRequirement
-#      department: Command
-#      time: 54000 # 15 hours
     - !type:AgeRequirement
       requiredAge: 21
-    - !type:TraitsRequirement # No Pacifist or Blind Sec
+    - !type:TraitsRequirement
       inverted: true
       traits:
-    - Pacifist
-    - Blindness
+      - Pacifist
+      - Blindness
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -3,6 +3,12 @@
   name: job-name-detective
   description: job-description-detective
   playTimeTracker: JobDetective
+  requirements:
+  - !type:TraitsRequirement # No Pacifist or Blind Sec
+    inverted: true
+    traits:
+    - Pacifist
+    - Blindness
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -17,6 +17,11 @@
 #      time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 21
+    - !type:TraitsRequirement # No Pacifist or Blind Sec
+    inverted: true
+    traits:
+    - Pacifist
+    - Blindness
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -4,24 +4,13 @@
   description: job-description-hos
   playTimeTracker: JobHeadOfSecurity
   requirements:
-#    - !type:RoleTimeRequirement
-#      role: JobWarden
-#      time: 10800 #3 hrs
-#    - !type:RoleTimeRequirement
-#      role: JobSecurityOfficer
-#      time: 36000 #10 hrs
-#    - !type:DepartmentTimeRequirement
-#      department: Security
-#      time: 108000 # 30 hrs
-#    - !type:OverallPlaytimeRequirement
-#      time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 21
     - !type:TraitsRequirement # No Pacifist or Blind Sec
       inverted: true
       traits:
-    - Pacifist
-    - Blindness
+      - Pacifist
+      - Blindness
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -18,8 +18,8 @@
     - !type:AgeRequirement
       requiredAge: 21
     - !type:TraitsRequirement # No Pacifist or Blind Sec
-    inverted: true
-    traits:
+      inverted: true
+      traits:
     - Pacifist
     - Blindness
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -3,6 +3,12 @@
   name: job-name-cadet
   description: job-description-cadet
   playTimeTracker: JobSecurityCadet
+  requirements:
+  - !type:TraitsRequirement # No Pacifist or Blind Sec
+    inverted: true
+    traits:
+    - Pacifist
+    - Blindness
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -3,6 +3,12 @@
   name: job-name-security
   description: job-description-security
   playTimeTracker: JobSecurityOfficer
+  requirements:
+  - !type:TraitsRequirement # No Pacifist or Blind Sec
+    inverted: true
+    traits:
+    - Pacifist
+    - Blindness
   startingGear: SecurityOfficerGear
   icon: "JobIconSecurityOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -3,6 +3,12 @@
   name: job-name-warden
   description: job-description-warden
   playTimeTracker: JobWarden
+  requirements:
+  - !type:TraitsRequirement # No Pacifist or Blind Sec
+    inverted: true
+    traits:
+    - Pacifist
+    - Blindness
   startingGear: WardenGear
   icon: "JobIconWarden"
   requireAdminNotify: true


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Made it so you cannot play sec or captain if you're blind or a pacifist. 
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
In the wise words of a spess man, "blind secoff is basically cooperating with antags without good reason, and pacifist batong might be removed leaving them completely useless" also how would someone be promoted to captain and not use their gun or sword??

### **Changelog**

:cl:
- remove: ~~Fired~~ Removed blind pacifist sec officers and captains
