### PR TITLE
Remove Wizden poster

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
@@ -175,5 +175,5 @@
       - PosterLegitSafetyMothMeth
       - PosterLegitSafetyMothHardhat
       - PosterLegitSafetyMothSSD
-      - PosterLegitOppenhopper
+      #- PosterLegitOppenhopper # GreyStation - Removed due to not pertaining to Grey Station
     chance: 1

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -1069,14 +1069,14 @@
   - type: Sprite
     state: poster52_legit
 
-- type: entity
-  parent: PosterBase
-  id: PosterLegitOppenhopper
-  name: "Oppenhopper"
-  description: "A poster for a long-forgotten movie. It follows a group of tenacious greenhorns from the Grasshopper Sector as they defend against onslaughts of the infamous Nuclear Operatives. The tagline reads: \"Nuke Ops will continue until robustness improves.\""
-  components:
-  - type: Sprite
-    state: poster53_legit
+#- type: entity # GreyStation - Removed due to not pertaining to Grey Station
+#  parent: PosterBase
+#  id: PosterLegitOppenhopper
+#  name: "Oppenhopper"
+#  description: "A poster for a long-forgotten movie. It follows a group of tenacious greenhorns from the Grasshopper Sector as they defend against onslaughts of the infamous Nuclear Operatives. The tagline reads: \"Nuke Ops will continue until robustness improves.\""
+#  components:
+#  - type: Sprite
+#    state: poster53_legit
 
 
 #maps


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed Oppenhopper poster
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It doesn't make sense for downstream forks because Hopper is a wizden server and wizden inside joke that doesn't make sense for general players.

**Changelog**
:cl:
- remove: Removed Oppenhopper Poster
