### PR TITLE
Fix roundstart.yml

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -292,10 +292,10 @@
     children:
       - !type:NestedSelector
         tableId: UnknownShuttlesFriendlyTable
-      - !type:NestedSelector
-        tableId: UnknownShuttlesFreelanceTable
-      #- !type:NestedSelector - Removed from GreyStation
-        #tableId: UnknownShuttlesHostileTable
+#      - !type:NestedSelector - Removed from GreyStation
+#        tableId: UnknownShuttlesFreelanceTable
+#      - !type:NestedSelector - Removed from GreyStation
+#        tableId: UnknownShuttlesHostileTable
 
 - type: entity
   id: BasicStationEventScheduler


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed error from upstream merge of not updating to roundstart that the freelance shuttle event is removed.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
To fix errors and because syndie disaster victim doesn't add much to the game besides wasting sec's time and creating issues for players on whether to trust or not trust them.

**Changelog**
:cl:
- remove: Removed free lance shuttle event