### PR TITLE
Tweak Space Lizard Plush

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -16,8 +16,8 @@
         weight: 9
       - id: PlushieSpaceLizard
         weight: 1
-      - id: PlushieLizardInversed
-        weight: 0.5
+#      - id: PlushieLizardInversed # GreyStation - Removed bloat
+#        weight: 0.5
     - !type:GroupSelector
       children:
       - id: PlushieCarp

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -428,65 +428,65 @@
           Quantity: 10
         - ReagentId: JuiceThatMakesYouWeh
           Quantity: 10
-  - type: Clothing
-    slots:
-    - HEAD
-    quickEquip: false
-    clothingVisuals:
-      head:
-      - state: spacelizard-equipped-HELMET
-        offset: "0, 0.03"
+#  - type: Clothing # GreyStation - Removed because not every plushie is capable of being a hat
+#    slots:
+#    - HEAD
+#    quickEquip: false
+#    clothingVisuals:
+#      head:
+#      - state: spacelizard-equipped-HELMET
+#        offset: "0, 0.03"
 
-- type: entity
-  parent: PlushieLizard
-  id: PlushieLizardInversed #Hew!
-  name: drazil plushie
-  description: An adorable stuffed toy that resembles a lizardperson from an inversed dimension. Hew!
-  components:
-  - type: Sprite
-    state: plushie_lizard_inversed
-  - type: Item
-    heldPrefix: plushielizardinversed
-  - type: EmitSoundOnUse
-    sound:
-      path: /Audio/Items/Toys/hew.ogg
-  - type: EmitSoundOnLand
-    sound:
-      path: /Audio/Items/Toys/hew.ogg
-  - type: EmitSoundOnActivate
-    sound:
-      path: /Audio/Items/Toys/hew.ogg
-  - type: EmitSoundOnTrigger
-    sound:
-      path: /Audio/Items/Toys/hew.ogg
-  - type: Food
-    requiresSpecialDigestion: true
-    useSound:
-      path: /Audio/Items/Toys/hew.ogg
-  - type: MeleeWeapon
-    wideAnimationRotation: 180
-    soundHit:
-      path: /Audio/Items/Toys/hew.ogg
-  - type: Extractable
-    juiceSolution:
-      reagents:
-      - ReagentId: JuiceThatMakesYouHew
-        Quantity: 30
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Fiber
-          Quantity: 10
-        - ReagentId: JuiceThatMakesYouHew
-          Quantity: 10
-  - type: Clothing
-    quickEquip: false
-    sprite: Objects/Fun/toys.rsi
-    equippedPrefix: lizard-inversed
-    slots:
-    - HEAD
+#- type: entity # GreyStation - Removed bloat
+#  parent: PlushieLizard
+#  id: PlushieLizardInversed #Hew!
+#  name: drazil plushie
+#  description: An adorable stuffed toy that resembles a lizardperson from an inversed dimension. Hew!
+#  components:
+#  - type: Sprite
+#    state: plushie_lizard_inversed
+#  - type: Item
+#    heldPrefix: plushielizardinversed
+#  - type: EmitSoundOnUse
+#    sound:
+#      path: /Audio/Items/Toys/hew.ogg
+#  - type: EmitSoundOnLand
+#    sound:
+#      path: /Audio/Items/Toys/hew.ogg
+#  - type: EmitSoundOnActivate
+#    sound:
+#      path: /Audio/Items/Toys/hew.ogg
+#  - type: EmitSoundOnTrigger
+#    sound:
+#      path: /Audio/Items/Toys/hew.ogg
+#  - type: Food
+#    requiresSpecialDigestion: true
+#    useSound:
+#      path: /Audio/Items/Toys/hew.ogg
+#  - type: MeleeWeapon
+#    wideAnimationRotation: 180
+#    soundHit:
+#      path: /Audio/Items/Toys/hew.ogg
+#  - type: Extractable
+#    juiceSolution:
+#      reagents:
+#      - ReagentId: JuiceThatMakesYouHew
+#        Quantity: 30
+#  - type: SolutionContainerManager
+#    solutions:
+#      food:
+#        maxVol: 20
+#        reagents:
+#        - ReagentId: Fiber
+#          Quantity: 10
+#        - ReagentId: JuiceThatMakesYouHew
+#          Quantity: 10
+#  - type: Clothing
+#    quickEquip: false
+#    sprite: Objects/Fun/toys.rsi
+#    equippedPrefix: lizard-inversed
+#    slots:
+#    - HEAD
 
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed the ability to wear the space lizard plush as a hat and also removing the reverse weh plushie.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Too much lizard plushie bloat content.

**Changelog**
:cl:
- remove: Removed reverse lizard plushie and ability to wear space lizard plushie as a hat
