### PR TITLE
Reverts 1:1 portview (for now)

### DIFF
--- a/Content.Client/Gameplay/GameplayState.cs
+++ b/Content.Client/Gameplay/GameplayState.cs
@@ -113,7 +113,11 @@ namespace Content.Client.Gameplay
 
         private void LoadMainScreen()
         {
-            var screenType = ScreenType.Separated; // GreyStation: Ignore cvar and force separated hud
+            var screenTypeString = _configurationManager.GetCVar(CCVars.UILayout);
+            if (!Enum.TryParse(screenTypeString, out ScreenType screenType))
+            {
+                screenType = default;
+            }
 
             switch (screenType)
             {

--- a/Content.Client/UserInterface/Systems/Viewport/ViewportUIController.cs
+++ b/Content.Client/UserInterface/Systems/Viewport/ViewportUIController.cs
@@ -18,7 +18,7 @@ public sealed class ViewportUIController : UIController
     [Dependency] private readonly IEntityManager _entMan = default!;
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;
     [UISystemDependency] private readonly SharedTransformSystem? _transformSystem = default!;
-    public static readonly Vector2i ViewportSize = (EyeManager.PixelsPerMeter * 15, EyeManager.PixelsPerMeter * 15); // GreyStation - 1:1 viewport
+    public static readonly Vector2i ViewportSize = (EyeManager.PixelsPerMeter * 21, EyeManager.PixelsPerMeter * 15);
     public const int ViewportHeight = 15;
     private MainViewport? Viewport => UIManager.ActiveScreen?.GetWidget<MainViewport>();
 
@@ -47,7 +47,17 @@ public sealed class ViewportUIController : UIController
 
         var min = _configurationManager.GetCVar(CCVars.ViewportMinimumWidth);
         var max = _configurationManager.GetCVar(CCVars.ViewportMaximumWidth);
-        var width = ViewportHeight; // GreyStation - 1:1 viewport
+        var width = _configurationManager.GetCVar(CCVars.ViewportWidth);
+        var verticalfit = _configurationManager.GetCVar(CCVars.ViewportVerticalFit) && _configurationManager.GetCVar(CCVars.ViewportStretch);
+
+        if (verticalfit)
+        {
+            width = max;
+        }
+        else if (width < min || width > max)
+        {
+            width = CCVars.ViewportWidth.DefaultValue;
+        }
 
         Viewport.Viewport.ViewportSize = (EyeManager.PixelsPerMeter * width, EyeManager.PixelsPerMeter * ViewportHeight);
         Viewport.UpdateCfg();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Reverts 1:1 port viewe.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
In it's current state the overlay UI for inventory/health and chat don't line up well with the port view.